### PR TITLE
NAS-123364 / 23.10-BETA.1 / fix register_ignore_key (by yocalebo)

### DIFF
--- a/nvme.pyx
+++ b/nvme.pyx
@@ -133,7 +133,7 @@ cdef class NvmeDevice(object):
         '''
         Registers a `key` to a disk ignoring any keys that already exist that are owned by this host.
         '''
-        reservation_registration_action = (0 & 0x7)
+        reservation_registration_action = (nvme.resv_register_action.replace & 0x7)
         ignore_existing_registration_key = (1 << 3)
         change_persist_thru_powerloss = (2 << 30)
         cdw10 = reservation_registration_action | ignore_existing_registration_key | change_persist_thru_powerloss
@@ -145,7 +145,11 @@ cdef class NvmeDevice(object):
         '''
         Registers a new `key` to the disk.
         '''
-        if not self.__submit_io(new_key=key, cdw10=(0 | (2 << 30))):
+        reservation_registration_action = (nvme.resv_register_action.register & 0x7)
+        ignore_existing_registration_key = 0
+        change_persist_thru_powerloss = (2 << 30)
+        cdw10 = reservation_registration_action | ignore_existing_registration_key | change_persist_thru_powerloss
+        if not self.__submit_io(new_key=key, cdw10=cdw10):
             raise OSError(f'Failed to register new key {key!r}')
         return True
 

--- a/pxd/nvme.pxd
+++ b/pxd/nvme.pxd
@@ -4,11 +4,17 @@ from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
 
 # NVMe SPEC: https://nvmexpress.org/wp-content/uploads/NVMe-NVM-Express-2.0a-2021.07.26-Ratified.pdf
 
-# See 7.2, Figure 392 Reservation Acquire - Command Dword 10
+# See 7.2, Figure 392 Reservation Acquire - Command Dword 10 (Bits 02:00)
 cdef enum resv_acquire_action:
     acquire = 0x00
     preempt = 0x01
     preempt_and_abort = 0x02
+
+# See 7.3, Figure 396: Reservation Register – Command Dword 10 (Bits 02:00)
+cdef enum resv_register_action:
+    register = 0x00
+    unregister = 0x01
+    replace = 0x02
 
 # See 7.4, Figure 394 Reservation Type Encoding
 ctypedef enum resv_type:


### PR DESCRIPTION
`py-fenced` daemon was crashing like so:
```
root@f60-146a[~]# fenced --foreground --exclude-disks nvme0n1 --force --no-panic        
[08-02-2023 08:29:16 (INFO) fenced.fence:init():93] - Host ID: 0xc5f27b48.
[08-02-2023 08:29:16 (INFO) fenced.fence:load_disks():43] - Clearing disks (if any)
[08-02-2023 08:29:16 (INFO) fenced.fence:load_disks():46] - Loading disks
[08-02-2023 08:29:16 (WARNING) fenced.disks:_run_batch():77] - method 'reset_keys' with args [1690990156] for disk <Disk: nvme1n1> failed.
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/fenced/disks.py", line 74, in _run_batch
    i.result()
  File "/usr/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/fenced/disks.py", line 147, in reset_keys
    self.disk.register_ignore_key(newkey)
  File "nvme.pyx", line 141, in nvme.NvmeDevice.register_ignore_key
OSError: Failed to register key 14263598520694634060
```

Further inspection showed that the drive had a current reservation key that was owned by this host.
```
root@f60-146a[~]# nvme resv-report /dev/nvme1n1

NVME Reservation status:

gen       : 8614
rtype     : 0
regctl    : 1
ptpls     : 0
regctl[0] :
  cntlid  : 1
  rcsts   : 0
  hostid  : 0
  rkey    : 75865fff64c32745
```
However, py-fenced determined that the owner of said reservation was not ourselves because the upper 32bit of the reservation key did not match the /etc/hostid of this node. This is extremely common during our QE cycles because often times the QE team will fresh install the systems over and over while testing which means /etc/hostid changes. However, the reservations stay on the disks because they do not pull power to the disks themselves. This means that the reservations from the previous install (different /etc/hostid) stay on the disks. py-fenced was determining this correctly and trying to register and ignore existing keys and setting the registration action to 0 (for register) which is a mistake since this host technically already had a reservation. Instead it needs to be 2 (replace). The nvme spec doesn't necessarily highlight this failure scenario but it's pretty self-explanatory once the problem is fully understood. This adds a proper enum in the definition file and references the spec where I got the values. Furthermore, it fixes the `register_ignore_key` by setting the action to 2 (replace) while also making the `register_new_key` use the new enum so this problem (in theory) doesn't happen again.

Original PR: https://github.com/truenas/py-nvme/pull/11
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123364