### PR TITLE
NAS-137163 / 25.10-BETA.1 / properly support 128 bit host ids (by yocalebo)

### DIFF
--- a/nvme.pyx
+++ b/nvme.pyx
@@ -20,9 +20,12 @@ cdef class NvmeDevice(object):
     cdef const char *dev
     cdef int nsid
     cdef int fd
+    cdef bint supports_128bit_hostid
 
     def __cinit__(self, path):
         self.dev = path
+        self.supports_128bit_hostid = False
+
         with nogil:
             # get file descriptor
             self.fd = open(self.dev, O_RDONLY)
@@ -34,55 +37,119 @@ cdef class NvmeDevice(object):
             if self.nsid <= 0:
                 raise OSError(errno, strerror(errno), self.dev)
 
+        self.__identify_controller()
+
     def __dealloc__(self):
         with nogil:
             if self.fd != -1:
                 close(self.fd)
 
+    def __identify_controller(self):
+        cdef nvme.nvme_passthru_cmd cmd
+        cdef nvme.nvme_id_ctrl *ctrl_data
+        cdef int ret
+        cdef uint32_t ctratt_value
+        cdef int err
+
+        err = posix_memalign(<void **>&ctrl_data, nvme.getpagesize(), 4096)
+        if err != 0:
+            raise MemoryError('Failed to allocate memory for identify controller')
+
+        try:
+            # Get controller attributes to check for 128-bit host ID support
+            memset(&cmd, 0, sizeof(cmd))
+            memset(ctrl_data, 0, 4096)
+            cmd.opcode = nvme.nvme_admin_identify
+            cmd.nsid = 0  # Controller level command
+            cmd.addr = <uint64_t><uintptr_t>ctrl_data
+            cmd.data_len = 4096
+            cmd.cdw10 = nvme.NVME_ID_CNS_CTRL
+            cmd.timeout_ms = NVME_DEFAULT_IOCTL_TIMEOUT_MS
+            ret = ioctl(self.fd, nvme.NVME_IOCTL_ADMIN_CMD, &cmd)
+            if ret == 0:
+                # Check bit 0 of ctratt for 128-bit Host Identifier support
+                ctratt_value = nvme.le32toh(ctrl_data.ctratt)
+                self.supports_128bit_hostid = bool(ctratt_value & 0x01)
+        finally:
+            free(ctrl_data)
+
+
     def __resv_report(self):
         cdef nvme.nvme_passthru_cmd pt
-        cdef nvme.nvme_resv_status *status
+        cdef void *buffer
+        cdef nvme.nvme_reservation_status *status
+        cdef nvme.nvme_reservation_status_ext *status_ext
         cdef int size = 4096
-        cdef bint eds = False
+        cdef bint eds = self.supports_128bit_hostid
         cdef int err = -1
+        cdef int regctl
+        cdef int ctrl_size
+        cdef int header_size
+        cdef int i, j
 
         # where the result is stored
-        err = posix_memalign(<void **>&status, nvme.getpagesize(), size)
+        err = posix_memalign(&buffer, nvme.getpagesize(), size)
         if err != 0:
             raise MemoryError('No memory for reading reservation keys')
-        memset(status, 0, size)
 
-        # the formatted ioctl command
+        memset(buffer, 0, size)
         memset(&pt, 0, sizeof(pt))
         pt.opcode = nvme.nvme_op_codes.nvme_cmd_resv_report
         pt.nsid = self.nsid
         pt.cdw10 = (size >> 2) - 1
         pt.cdw11 = eds
-        pt.addr = <uint64_t><uintptr_t>status
+        pt.addr = <uint64_t><uintptr_t>buffer
         pt.data_len = size
         pt.timeout_ms = NVME_DEFAULT_IOCTL_TIMEOUT_MS
         err = ioctl(self.fd, nvme.NVME_IOCTL_IO_CMD, &pt)
         if err < 0:
+            free(buffer)
             raise OSError('Failed to issue ioctl')
 
-        # registered controllers
-        regctl = status.regctl[0] | (status.regctl[1] << 8)
-
         info = {}
-        info['generation'] = nvme.le32toh(status.gen)
-        info['scopetype'] = status.rtype
-        info['number_of_registered_controllers'] = regctl
-        info['persist_through_power_loss_state'] = status.ptpls
-        info['controllers'] = []
-        for i in range(int(min(regctl, (size - 24 / 24)))):
-            info['controllers'].append({
-                'controller_id': nvme.le16toh(status.ctrlr[i].ctrlr_id),
-                'resv_status': status.ctrlr[i].rcsts,
-                'host_id': nvme.le64toh(status.ctrlr[i].hostid),
-                'key': nvme.le64toh(status.ctrlr[i].rkey)
-            })
+        if eds:
+            # Extended format with 128-bit host IDs
+            status_ext = <nvme.nvme_reservation_status_ext *>buffer
+            regctl = status_ext.regctl[0] | (status_ext.regctl[1] << 8)
+            ctrl_size = sizeof(nvme.nvme_registered_ctrl_ext)
+            header_size = 64
+            info['generation'] = nvme.le32toh(status_ext.gen)
+            info['scopetype'] = status_ext.rtype
+            info['number_of_registered_controllers'] = regctl
+            info['persist_through_power_loss_state'] = status_ext.ptpls
+            info['controllers'] = []
+            for i in range(int(min(regctl, (size - header_size) // ctrl_size))):
+                # Build 128-bit host ID as hex string
+                host_id_str = ''
+                for j in range(16):
+                    host_id_str += '{:02x}'.format(status_ext.ctrlr[i].hostid[j])
 
-        free(status)
+                info['controllers'].append({
+                    'controller_id': nvme.le16toh(status_ext.ctrlr[i].ctrlr_id),
+                    'resv_status': status_ext.ctrlr[i].rcsts,
+                    'host_id': host_id_str,
+                    'key': nvme.le64toh(status_ext.ctrlr[i].rkey)
+                })
+        else:
+            # Standard format with 64-bit host IDs
+            status = <nvme.nvme_reservation_status *>buffer
+            regctl = status.regctl[0] | (status.regctl[1] << 8)
+            ctrl_size = sizeof(nvme.nvme_registered_ctrl)
+            header_size = 24
+            info['generation'] = nvme.le32toh(status.gen)
+            info['scopetype'] = status.rtype
+            info['number_of_registered_controllers'] = regctl
+            info['persist_through_power_loss_state'] = status.ptpls
+            info['controllers'] = []
+            for i in range(int(min(regctl, (size - header_size) // ctrl_size))):
+                info['controllers'].append({
+                    'controller_id': nvme.le16toh(status.ctrlr[i].ctrlr_id),
+                    'resv_status': status.ctrlr[i].rcsts,
+                    'host_id': nvme.le64toh(status.ctrlr[i].hostid),
+                    'key': nvme.le64toh(status.ctrlr[i].rkey)
+                })
+
+        free(buffer)
         return info
 
     def read_keys(self):
@@ -92,7 +159,9 @@ cdef class NvmeDevice(object):
             2. the specific keys that have been put on the disk (keys)
         '''
         d = self.__resv_report()
-        return {'generation': d['generation'], 'keys': [i['key'] for i in d['controllers']]}
+        # Return unique keys only (multiple controllers might use the same key)
+        unique_keys = list(set(i['key'] for i in d['controllers']))
+        return {'generation': d['generation'], 'keys': unique_keys}
 
     def read_reservation(self):
         '''
@@ -102,10 +171,17 @@ cdef class NvmeDevice(object):
             3. the reservation key that reserves the disk (reservation)
         '''
         d = self.__resv_report()
+        # Find the controller that holds the reservation (rcsts bit 0 = 1)
+        reservation_key = None
+        for controller in d['controllers']:
+            if controller['resv_status'] & 0x01:  # Bit 0 indicates reservation holder
+                reservation_key = controller['key']
+                break
+
         return {
             'generation': d['generation'],
             'scopetype': d['scopetype'],
-            'reservation': d['controllers'][0]['key'] if d['controllers'] else None,
+            'reservation': reservation_key,
         }
 
     def __submit_io(self, cur_key=0, new_key=0, cdw10=0, opcode=nvme.nvme_op_codes.nvme_cmd_resv_register):
@@ -151,7 +227,6 @@ cdef class NvmeDevice(object):
             cdw10 = reservation_registration_action | ignore_existing_registration_key | change_persist_thru_powerloss
             if not self.__submit_io(new_key=key, cdw10=cdw10):
                 raise OSError(f'Failed to register, ignore and register, replace key {key!r}')
-
         return True
 
     def register_new_key(self, key):

--- a/pxd/nvme.pxd
+++ b/pxd/nvme.pxd
@@ -58,26 +58,161 @@ cdef extern from "linux/nvme_ioctl.h":
 
     enum:
         NVME_IOCTL_IO_CMD
+        NVME_IOCTL_ADMIN_CMD
         NVME_IOCTL_ID
 
 ctypedef enum nvme_op_codes:
+    nvme_admin_identify = 0x06
     nvme_cmd_resv_register = 0x0d
     nvme_cmd_resv_report = 0x0e
     nvme_cmd_resv_acquire = 0x11
     nvme_cmd_resv_release = 0x15
 
-ctypedef struct nvme_resv_reg_ctrlr:
+# CNS values for Identify command
+cdef enum nvme_id_cns:
+    NVME_ID_CNS_NS = 0x00      # Identify Namespace
+    NVME_ID_CNS_CTRL = 0x01    # Identify Controller
+    NVME_ID_CNS_NS_ACTIVE = 0x02  # Active Namespace ID list
+    NVME_ID_CNS_NS_DESC = 0x03    # Namespace Identification Descriptor list
+
+# include/linux/nvme.h
+ctypedef struct nvme_registered_ctrl:
     uint16_t ctrlr_id
     uint8_t rcsts
-    uint8_t resv3[5]
+    uint8_t rsvd3[5]
     uint64_t hostid
     uint64_t rkey
 
-ctypedef struct nvme_resv_status:
+ctypedef struct nvme_reservation_status:
     uint32_t gen
     uint8_t rtype
     uint8_t regctl[2]
     uint8_t resv5[2]
     uint8_t ptpls
-    uint8_t resv10[13]
-    nvme_resv_reg_ctrlr ctrlr[0]
+    uint8_t resv10[14]
+    nvme_registered_ctrl ctrlr[0]
+
+# Extended controller structure for 128-bit host IDs (when EDS=1)
+ctypedef struct nvme_registered_ctrl_ext:
+    uint16_t ctrlr_id
+    uint8_t rcsts
+    uint8_t rsvd3[5]
+    uint64_t rkey
+    uint8_t hostid[16]
+    uint8_t rsvd32[32]
+
+ctypedef struct nvme_reservation_status_ext:
+    uint32_t gen
+    uint8_t rtype
+    uint8_t regctl[2]
+    uint8_t resv5[2]
+    uint8_t ptpls
+    uint8_t resv10[14]
+    uint8_t rsvd24[40];
+    nvme_registered_ctrl_ext ctrlr[0]
+
+
+# Power state descriptor
+ctypedef struct nvme_id_power_state:
+    uint16_t max_power
+    uint8_t rsvd2
+    uint8_t flags
+    uint32_t entry_lat
+    uint32_t exit_lat
+    uint8_t read_tput
+    uint8_t read_lat
+    uint8_t write_tput
+    uint8_t write_lat
+    uint16_t idle_power
+    uint8_t idle_scale
+    uint8_t rsvd19
+    uint16_t active_power
+    uint8_t active_work_scale
+    uint8_t rsvd23[9]
+
+# Controller identify structure (include/linux/nvme.h)
+ctypedef struct nvme_id_ctrl:
+    uint16_t vid
+    uint16_t ssvid
+    char sn[20]
+    char mn[40]
+    char fr[8]
+    uint8_t rab
+    uint8_t ieee[3]
+    uint8_t cmic
+    uint8_t mdts
+    uint16_t cntlid
+    uint32_t ver
+    uint32_t rtd3r
+    uint32_t rtd3e
+    uint32_t oaes
+    uint32_t ctratt
+    uint8_t rsvd100[11]
+    uint8_t cntrltype
+    uint8_t fguid[16]
+    uint16_t crdt1
+    uint16_t crdt2
+    uint16_t crdt3
+    uint8_t rsvd134[122]
+    uint16_t oacs
+    uint8_t acl
+    uint8_t aerl
+    uint8_t frmw
+    uint8_t lpa
+    uint8_t elpe
+    uint8_t npss
+    uint8_t avscc
+    uint8_t apsta
+    uint16_t wctemp
+    uint16_t cctemp
+    uint16_t mtfa
+    uint32_t hmpre
+    uint32_t hmmin
+    uint8_t tnvmcap[16]
+    uint8_t unvmcap[16]
+    uint32_t rpmbs
+    uint16_t edstt
+    uint8_t dsto
+    uint8_t fwug
+    uint16_t kas
+    uint16_t hctma
+    uint16_t mntmt
+    uint16_t mxtmt
+    uint32_t sanicap
+    uint32_t hmminds
+    uint16_t hmmaxd
+    uint8_t rsvd338[4]
+    uint8_t anatt
+    uint8_t anacap
+    uint32_t anagrpmax
+    uint32_t nanagrpid
+    uint8_t rsvd352[160]
+    uint8_t sqes
+    uint8_t cqes
+    uint16_t maxcmd
+    uint32_t nn
+    uint16_t oncs
+    uint16_t fuses
+    uint8_t fna
+    uint8_t vwc
+    uint16_t awun
+    uint16_t awupf
+    uint8_t nvscc
+    uint8_t nwpc
+    uint16_t acwu
+    uint8_t rsvd534[2]
+    uint32_t sgls
+    uint32_t mnan
+    uint8_t rsvd544[224]
+    char subnqn[256]
+    uint8_t rsvd1024[768]
+    uint32_t ioccsz
+    uint32_t iorcsz
+    uint16_t icdoff
+    uint8_t ctrattr
+    uint8_t msdbd
+    uint8_t rsvd1804[2]
+    uint8_t dctype
+    uint8_t rsvd1807[241]
+    nvme_id_power_state psd[32]
+    uint8_t vs[1024]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from Cython.Build import cythonize
 
 setup(
     name='nvme',
-    version='0.0.2',
+    version='0.0.3',
     setup_requires=[
         'setuptools>=45.0',
         'Cython',


### PR DESCRIPTION
When an nvme controller reports itself as supporting 128bit host-ids and it's accessed over fabrics, the specification dictates that it _MUST_ use 128bit host ids. To support 128bit host-ids, I've done the following:
1. added a private `__identify_controller` method that sends an identify admin command to parse the `ctrattr` (controller attributes) bits. Bit 0 indicates whether or not the disk supports 128bit host ids.
2. extended `read_keys` and `read_reservation` to parse `eds` (extended data structure) for reservations that are being used for drives that are connected over fabric AND use 128bit host ids.

This is a rather involved portion of the specification but if someone is morbidly curious Cf. NVMe Base Specification, Revision 2.1 section 5.1.25.1.28.

Original PR: https://github.com/truenas/py-nvme/pull/19
